### PR TITLE
Left Associative Ternary in PHP

### DIFF
--- a/wat.php
+++ b/wat.php
@@ -1,0 +1,2 @@
+<?php
+echo (true ? 'Foo' : false ? 'Bar' : 'Baz'); // Bar


### PR DESCRIPTION
PHP has left associative ternaries instead of right associative ones like most other languages. Throwing in brackets on the right hand ternary fixes it. 

Apologies for the incorrect commit description, I got my left and right confused for a moment. ;)
