### PR TITLE
Add to wat.js

### DIFF
--- a/wat.js
+++ b/wat.js
@@ -10,7 +10,9 @@
 */
 
 {} + []; // 0
+({} + []); // "[object Object]"
 {} + {}; // NaN
+({} + {}); // "[object Object][object Object]"
 [0, -1, -2].sort(); // [-1, -2, 0]
 ',,,' == new Array(4) // true
 ["1", "2", "3", "4", "5", "6", "7", "8", "9"].map(parseInt) // [ 1, NaN, NaN, NaN, NaN, NaN, NaN, NaN, NaN ]


### PR DESCRIPTION
`{} + E;` is parsed as `{}; +E;`, i.e. an empty code block followed by a unary plus. To make it parse as a binary plus you need to surround with parenthesis.
